### PR TITLE
Bump Selenium version to 4.17.0

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,7 @@ Assuming you want to use Java 11, Junit and AssertJ please add the following dep
 
 <properties>
     <fluentlenium.version>6.0.0</fluentlenium.version>
-    <selenium.version>4.10.0</selenium.version>
+    <selenium.version>4.17.0</selenium.version>
 </properties>
 
 <dependency>

--- a/examples/appium/pom.xml
+++ b/examples/appium/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <fluentlenium.version>6.0.0</fluentlenium.version>
         <spring.version>6.1.1</spring.version>
-        <appium.selenium.version>4.10.0</appium.selenium.version>
+        <appium.selenium.version>4.17.0</appium.selenium.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/cucumber/pom.xml
+++ b/examples/cucumber/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <java.version>11</java.version>
         <fluentlenium.version>6.0.0</fluentlenium.version>
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.17.0</selenium.version>
     </properties>
 
     <dependencies>

--- a/examples/hooks/pom.xml
+++ b/examples/hooks/pom.xml
@@ -12,7 +12,7 @@
         <fluentlenium.version>6.0.0</fluentlenium.version>
 
         <!-- Make sure the selenium.version won't be overriden by another pom.xml -->
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.17.0</selenium.version>
     </properties>
 
     <name>FluentLenium Examples Quickstart</name>

--- a/examples/kotest/build.gradle.kts
+++ b/examples/kotest/build.gradle.kts
@@ -57,10 +57,10 @@ dependencies {
 
     testImplementation("io.github.bonigarcia:webdrivermanager:5.6.2")
 
-    val seleniumVersion = properties["selenium.version"] ?: "4.10.0"
+    val seleniumVersion = properties["selenium.version"] ?: "4.17.0"
     testImplementation("org.seleniumhq.selenium:selenium-api:$seleniumVersion")
     testImplementation("org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion")
-    testRuntimeOnly("org.seleniumhq.selenium:selenium-devtools-v113:$seleniumVersion")
+    testRuntimeOnly("org.seleniumhq.selenium:selenium-devtools-v119:$seleniumVersion")
 
     testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:2.0.2")
     testImplementation("org.testcontainers:selenium:1.19.3")

--- a/examples/performance/pom.xml
+++ b/examples/performance/pom.xml
@@ -12,7 +12,7 @@
         <fluentlenium.version>6.0.0</fluentlenium.version>
 
         <!-- Make sure the selenium.version won't be overridden by another pom.xml -->
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.17.0</selenium.version>
     </properties>
 
     <name>FluentLenium Examples Performance Timing</name>

--- a/examples/quickstart-chrome/pom.xml
+++ b/examples/quickstart-chrome/pom.xml
@@ -12,7 +12,7 @@
         <fluentlenium.version>6.0.0</fluentlenium.version>
 
         <!-- Make sure the selenium.version won't be overriden by another pom.xml -->
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.17.0</selenium.version>
     </properties>
 
     <name>FluentLenium Examples Chrome</name>

--- a/examples/quickstart-firefox/build.gradle
+++ b/examples/quickstart-firefox/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation "io.fluentlenium:fluentlenium-junit-jupiter:$fluentLeniumVersion"
     implementation "io.fluentlenium:fluentlenium-assertj:$fluentLeniumVersion"
     testImplementation 'ch.qos.logback:logback-classic:1.4.13'
-    testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:4.10.0'
+    testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:4.17.0'
     testImplementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"

--- a/examples/quickstart-microsoft-browsers/pom.xml
+++ b/examples/quickstart-microsoft-browsers/pom.xml
@@ -12,7 +12,7 @@
         <fluentlenium.version>6.0.0</fluentlenium.version>
 
         <!-- Make sure the selenium.version won't be overriden by another pom.xml -->
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.17.0</selenium.version>
     </properties>
 
     <name>FluentLenium Examples Edge IE</name>
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v112</artifactId>
+            <artifactId>selenium-devtools-v119</artifactId>
             <version>${selenium.version}</version>
             <scope>test</scope>
         </dependency>

--- a/examples/quickstart-safari/pom.xml
+++ b/examples/quickstart-safari/pom.xml
@@ -12,7 +12,7 @@
         <fluentlenium.version>6.0.0</fluentlenium.version>
 
         <!-- Make sure the selenium.version won't be overriden by another pom.xml -->
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.17.0</selenium.version>
     </properties>
 
     <name>FluentLenium Examples Safari</name>

--- a/examples/spock/pom.xml
+++ b/examples/spock/pom.xml
@@ -15,7 +15,7 @@
         <fluentlenium.version>6.0.0</fluentlenium.version>
 
         <!-- Make sure the selenium.version won't be overriden by another pom.xml -->
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.17.0</selenium.version>
     </properties>
 
     <dependencies>

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <fluentlenium.version>6.0.0</fluentlenium.version>
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.17.0</selenium.version>
     </properties>
 
     <build>

--- a/fluentlenium-assertj/pom.xml
+++ b/fluentlenium-assertj/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-assertj</artifactId>
     <packaging>jar</packaging>

--- a/fluentlenium-assertj/src/main/java/io/fluentlenium/assertj/custom/FluentWebElementAssert.java
+++ b/fluentlenium-assertj/src/main/java/io/fluentlenium/assertj/custom/FluentWebElementAssert.java
@@ -1,7 +1,7 @@
 package io.fluentlenium.assertj.custom;
 
 import io.fluentlenium.core.domain.FluentWebElement;
-import io.netty.util.internal.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.StringAssert;
 import org.openqa.selenium.Dimension;
@@ -165,7 +165,7 @@ public class FluentWebElementAssert extends AbstractFluentAssert<FluentWebElemen
     public FluentWebElementAssert hasClasses(String... classesToFind) {
         String actualClasses = actual.attribute(CLASS_ATTRIBUTE);
 
-        if (StringUtil.isNullOrEmpty(actualClasses)) {
+        if (StringUtils.isEmpty(actualClasses)) {
             failWithMessage("The element has no class attribute.");
         }
 
@@ -249,7 +249,7 @@ public class FluentWebElementAssert extends AbstractFluentAssert<FluentWebElemen
     public AbstractStringAssert hasAttribute(String attribute) {
         String actualValue = actual.attribute(attribute);
 
-        if (StringUtil.isNullOrEmpty(actualValue)) {
+        if (StringUtils.isEmpty(actualValue)) {
             failWithMessage("The element does not have attribute " + attribute);
         }
 
@@ -258,7 +258,7 @@ public class FluentWebElementAssert extends AbstractFluentAssert<FluentWebElemen
 
     @Override
     public FluentWebElementAssert hasNotAttribute(String attribute) {
-        if (!StringUtil.isNullOrEmpty(actual.attribute(attribute))) {
+        if (StringUtils.isNotEmpty(actual.attribute(attribute))) {
             failWithMessage("The element has attribute " + attribute);
         }
         return this;

--- a/fluentlenium-core/pom.xml
+++ b/fluentlenium-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-core</artifactId>
     <packaging>jar</packaging>
@@ -46,32 +46,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-net</groupId>
-                    <artifactId>commons-net</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-text</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
@@ -95,6 +69,32 @@
         <dependency>
             <groupId>org.atteo.classindex</groupId>
             <artifactId>classindex</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-net</groupId>
+                    <artifactId>commons-net</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -170,7 +170,7 @@
                         <path>
                             <groupId>org.atteo.classindex</groupId>
                             <artifactId>classindex</artifactId>
-                            <version>3.13</version>
+                            <version>${classindex.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/fluentlenium-core/src/main/java/io/fluentlenium/adapter/sharedwebdriver/SharedWebdriverSingletonImpl.java
+++ b/fluentlenium-core/src/main/java/io/fluentlenium/adapter/sharedwebdriver/SharedWebdriverSingletonImpl.java
@@ -7,7 +7,7 @@ import io.fluentlenium.configuration.ConfigurationProperties.DriverLifecycle;
 import io.fluentlenium.configuration.WebDrivers;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.openqa.selenium.support.events.EventFiringDecorator;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -227,7 +227,7 @@ class SharedWebdriverSingletonImpl {
     public WebDriver newWebDriver(String name, Capabilities capabilities, Configuration configuration) {
         WebDriver webDriver = WebDrivers.INSTANCE.newWebDriver(name, capabilities, configuration);
         if (Boolean.TRUE.equals(configuration.getEventsEnabled())) {
-            webDriver = new EventFiringWebDriver(webDriver);
+            webDriver = new EventFiringDecorator<>().decorate(webDriver);
         }
         return webDriver;
     }

--- a/fluentlenium-core/src/main/java/io/fluentlenium/core/FluentDriver.java
+++ b/fluentlenium-core/src/main/java/io/fluentlenium/core/FluentDriver.java
@@ -38,7 +38,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsElement;
-import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.openqa.selenium.support.events.EventFiringDecorator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,7 +91,7 @@ public class FluentDriver extends AbstractFluentDriverSearchControl { // NOPMD G
         driverWait = new FluentDriverWait(configuration);
         this.driver = driver;
         search = new Search(driver, this, componentsManager, adapter);
-        if (driver instanceof EventFiringWebDriver) {
+        if (driver instanceof EventFiringDecorator) {
             events = new EventsRegistry(this);
             componentsEventsRegistry = new ComponentsEventsRegistry(events, componentsManager);
         } else {

--- a/fluentlenium-core/src/main/java/io/fluentlenium/core/events/EventAdapter.java
+++ b/fluentlenium-core/src/main/java/io/fluentlenium/core/events/EventAdapter.java
@@ -1,19 +1,14 @@
 package io.fluentlenium.core.events;
 
 import io.fluentlenium.core.components.ComponentInstantiator;
-import io.fluentlenium.core.domain.FluentWebElement;
-import org.openqa.selenium.By;
-import org.openqa.selenium.OutputType;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.events.WebDriverEventListener;
+import org.openqa.selenium.support.events.WebDriverListener;
 
 import java.util.Objects;
 
 /**
  * FluentLenium adapter for Selenium events listener.
  */
-class EventAdapter implements WebDriverEventListener {
+class EventAdapter implements WebDriverListener {
 
     private final EventListener listener;
     private final ComponentInstantiator instantiator;
@@ -27,147 +22,6 @@ class EventAdapter implements WebDriverEventListener {
     EventAdapter(EventListener listener, ComponentInstantiator instantiator) {
         this.listener = listener;
         this.instantiator = instantiator;
-    }
-
-    @Override
-    public void beforeNavigateTo(String url, WebDriver driver) {
-        listener.beforeNavigateTo(url, driver);
-    }
-
-    @Override
-    public void afterNavigateTo(String url, WebDriver driver) {
-        listener.afterNavigateTo(url, driver);
-    }
-
-    @Override
-    public void beforeNavigateBack(WebDriver driver) {
-        listener.beforeNavigateBack(driver);
-    }
-
-    @Override
-    public void afterNavigateBack(WebDriver driver) {
-        listener.afterNavigateBack(driver);
-    }
-
-    @Override
-    public void beforeNavigateForward(WebDriver driver) {
-        listener.beforeNavigateForward(driver);
-    }
-
-    @Override
-    public void afterNavigateForward(WebDriver driver) {
-        listener.afterNavigateForward(driver);
-    }
-
-    @Override
-    public void beforeNavigateRefresh(WebDriver driver) {
-        listener.beforeNavigateRefresh(driver);
-    }
-
-    @Override
-    public void afterNavigateRefresh(WebDriver driver) {
-        listener.afterNavigateRefresh(driver);
-    }
-
-    @Override
-    public void beforeFindBy(By by, WebElement element, WebDriver driver) {
-        listener
-                .beforeFindBy(by, element == null ? null : instantiator.newComponent(FluentWebElement.class, element), driver);
-    }
-
-    @Override
-    public void afterFindBy(By by, WebElement element, WebDriver driver) {
-        listener
-                .afterFindBy(by, element == null ? null : instantiator.newComponent(FluentWebElement.class, element), driver);
-    }
-
-    @Override
-    public void beforeClickOn(WebElement element, WebDriver driver) {
-        listener.beforeClickOn(element == null ? null : instantiator.newComponent(FluentWebElement.class, element), driver);
-    }
-
-    @Override
-    public void afterClickOn(WebElement element, WebDriver driver) {
-        listener.afterClickOn(element == null ? null : instantiator.newComponent(FluentWebElement.class, element), driver);
-    }
-
-    @Override
-    public void beforeChangeValueOf(WebElement element, WebDriver driver, CharSequence[] charSequence) {
-        listener
-                .beforeChangeValueOf(element == null ? null : instantiator.newComponent(FluentWebElement.class, element), driver,
-                        charSequence);
-    }
-
-    @Override
-    public void afterChangeValueOf(WebElement element, WebDriver driver, CharSequence[] charSequence) {
-        listener
-                .afterChangeValueOf(element == null ? null : instantiator.newComponent(FluentWebElement.class, element), driver,
-                        charSequence);
-    }
-
-    @Override
-    public void beforeScript(String script, WebDriver driver) {
-        listener.beforeScript(script, driver);
-    }
-
-    @Override
-    public void afterScript(String script, WebDriver driver) {
-        listener.afterScript(script, driver);
-    }
-
-    @Override
-    public void beforeSwitchToWindow(String s, WebDriver webDriver) {
-        listener.beforeSwitchToWindow(s, webDriver);
-    }
-
-    @Override
-    public void afterSwitchToWindow(String s, WebDriver webDriver) {
-        listener.afterSwitchToWindow(s, webDriver);
-    }
-
-    @Override
-    public void onException(Throwable throwable, WebDriver driver) {
-        listener.onException(throwable, driver);
-    }
-
-    @Override
-    public <X> void beforeGetScreenshotAs(OutputType<X> outputType) {
-        listener.beforeGetScreenshotAs(outputType);
-    }
-
-    @Override
-    public <X> void afterGetScreenshotAs(OutputType<X> outputType, X x) {
-        listener.afterGetScreenshotAs(outputType, x);
-    }
-
-    @Override
-    public void beforeAlertAccept(WebDriver driver) {
-        listener.beforeAlertAccept(driver);
-    }
-
-    @Override
-    public void afterAlertAccept(WebDriver driver) {
-        listener.afterAlertAccept(driver);
-    }
-
-    @Override
-    public void beforeAlertDismiss(WebDriver driver) {
-        listener.beforeAlertDismiss(driver);
-    }
-
-    @Override
-    public void afterAlertDismiss(WebDriver driver) {
-        listener.afterAlertDismiss(driver);
-    }
-
-    @Override
-    public void beforeGetText(WebElement webElement, WebDriver webDriver) {
-        listener.beforeGetText(instantiator.newComponent(FluentWebElement.class, webElement), webDriver);
-    }
-
-    @Override
-    public void afterGetText(WebElement webElement, WebDriver webDriver, String s) {
-        listener.afterGetText(instantiator.newComponent(FluentWebElement.class, webElement), webDriver, s);
     }
 
     @Override

--- a/fluentlenium-core/src/main/java/io/fluentlenium/core/performance/HtmlUnitPerformanceTimingMetrics.java
+++ b/fluentlenium-core/src/main/java/io/fluentlenium/core/performance/HtmlUnitPerformanceTimingMetrics.java
@@ -1,6 +1,6 @@
 package io.fluentlenium.core.performance;
 
-import com.gargoylesoftware.htmlunit.javascript.host.performance.PerformanceTiming;
+import org.htmlunit.javascript.host.performance.PerformanceTiming;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;

--- a/fluentlenium-core/src/main/java/io/fluentlenium/core/performance/PerformanceTimingMetricsFactory.java
+++ b/fluentlenium-core/src/main/java/io/fluentlenium/core/performance/PerformanceTimingMetricsFactory.java
@@ -1,6 +1,6 @@
 package io.fluentlenium.core.performance;
 
-import com.gargoylesoftware.htmlunit.javascript.host.performance.PerformanceTiming;
+import org.htmlunit.javascript.host.performance.PerformanceTiming;
 
 import java.util.Map;
 

--- a/fluentlenium-core/src/main/java/io/fluentlenium/utils/SeleniumVersionChecker.java
+++ b/fluentlenium-core/src/main/java/io/fluentlenium/utils/SeleniumVersionChecker.java
@@ -35,7 +35,7 @@ public final class SeleniumVersionChecker {
             "You are using incompatible Selenium version {}. Please change it to {}. "
                     + "You can find example on project main page {}";
 
-    private static final String EXPECTED_VERSION = "4.10.0";
+    private static final String EXPECTED_VERSION = "4.17.0";
     private static final String SELENIUM_GROUP_ID = "org.seleniumhq.selenium";
     private static final String FL_URL = "https://github.com/FluentLenium/FluentLenium";
     private static final String POM = "pom.xml";

--- a/fluentlenium-core/src/main/java/io/fluentlenium/utils/chromium/ChromiumControlImpl.java
+++ b/fluentlenium-core/src/main/java/io/fluentlenium/utils/chromium/ChromiumControlImpl.java
@@ -2,7 +2,7 @@ package io.fluentlenium.utils.chromium;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.openqa.selenium.support.events.EventFiringDecorator;
 
 public class ChromiumControlImpl implements ChromiumControl {
 
@@ -13,8 +13,8 @@ public class ChromiumControlImpl implements ChromiumControl {
     }
 
     public final ChromiumApi getChromiumApi() {
-        if (driver instanceof EventFiringWebDriver) {
-            driver = ((EventFiringWebDriver) driver).getWrappedDriver();
+        if (driver instanceof EventFiringDecorator) {
+            driver = new EventFiringDecorator<>().decorate(driver);
         }
 
         RemoteWebDriver remoteWebDriver;

--- a/fluentlenium-core/src/test/java/io/fluentlenium/adapter/FluentAdapterTest.java
+++ b/fluentlenium-core/src/test/java/io/fluentlenium/adapter/FluentAdapterTest.java
@@ -15,7 +15,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.openqa.selenium.support.events.EventFiringDecorator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -114,8 +114,8 @@ public class FluentAdapterTest {
             newWebDriver = adapter.newWebDriver();
             newWebDriver2 = adapter.newWebDriver();
 
-            assertThat(newWebDriver).isNotSameAs(newWebDriver2).isInstanceOf(EventFiringWebDriver.class);
-            assertThat(newWebDriver2).isInstanceOf(EventFiringWebDriver.class);
+            assertThat(newWebDriver).isNotSameAs(newWebDriver2).isInstanceOf(EventFiringDecorator.class);
+            assertThat(newWebDriver2).isInstanceOf(EventFiringDecorator.class);
 
             assertThat(((WrapsDriver) newWebDriver).getWrappedDriver()).isInstanceOf(HtmlUnitDriver.class);
             assertThat(((WrapsDriver) newWebDriver).getWrappedDriver()).isInstanceOf(HtmlUnitDriver.class);

--- a/fluentlenium-core/src/test/java/io/fluentlenium/core/events/EventsTest.java
+++ b/fluentlenium-core/src/test/java/io/fluentlenium/core/events/EventsTest.java
@@ -15,7 +15,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsElement;
-import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.openqa.selenium.support.events.EventFiringDecorator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -46,7 +46,7 @@ public class EventsTest {
     @Mock
     private WebDriver.Timeouts timeouts;
 
-    private EventFiringWebDriver eventDriver;
+    private WebDriver eventDriver;
 
     private ComponentInstantiator instantiator;
     private FluentAdapter fluentAdapter;
@@ -57,7 +57,7 @@ public class EventsTest {
         when(driver.manage()).thenReturn(options);
         when(options.timeouts()).thenReturn(timeouts);
 
-        eventDriver = new EventFiringWebDriver(driver);
+        eventDriver = new EventFiringDecorator<>().decorate(driver);
         fluentAdapter = new FluentAdapter();
         fluentAdapter.initFluent(eventDriver);
 
@@ -212,7 +212,7 @@ public class EventsTest {
 
         reset(beforeAllListener, afterAllListener, beforeToListener, afterToListener, beforeListener, afterListener);
 
-        eventDriver.executeScript("test");
+        ((JavascriptWebDriver) eventDriver).executeScript("test");
 
         verify(beforeScriptListener).on(eq("test"), notNull());
         verify(afterScriptListener).on(eq("test"), notNull());

--- a/fluentlenium-core/src/test/java/io/fluentlenium/core/performance/HtmlUnitPerformanceTimingMetricsTest.java
+++ b/fluentlenium-core/src/test/java/io/fluentlenium/core/performance/HtmlUnitPerformanceTimingMetricsTest.java
@@ -1,6 +1,6 @@
 package io.fluentlenium.core.performance;
 
-import com.gargoylesoftware.htmlunit.javascript.host.performance.PerformanceTiming;
+import org.htmlunit.javascript.host.performance.PerformanceTiming;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/fluentlenium-core/src/test/java/io/fluentlenium/core/performance/PerformanceTimingMetricsFactoryTest.java
+++ b/fluentlenium-core/src/test/java/io/fluentlenium/core/performance/PerformanceTimingMetricsFactoryTest.java
@@ -1,6 +1,6 @@
 package io.fluentlenium.core.performance;
 
-import com.gargoylesoftware.htmlunit.javascript.host.performance.PerformanceTiming;
+import org.htmlunit.javascript.host.performance.PerformanceTiming;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/fluentlenium-core/src/test/java/io/fluentlenium/utils/SeleniumVersionCheckerTestConstants.java
+++ b/fluentlenium-core/src/test/java/io/fluentlenium/utils/SeleniumVersionCheckerTestConstants.java
@@ -4,7 +4,7 @@ final class SeleniumVersionCheckerTestConstants {
 
     private static final String POM_NAME = "dummy_pom.xml";
     private static final String PATH_TO_TEST_FOLDER = "src/test/resources/io/fluentlenium/utils/poms/";
-    static final String EXPECTED_VERSION = "4.10.0";
+    static final String EXPECTED_VERSION = "4.17.0";
     static final String PARENT_POM = PATH_TO_TEST_FOLDER + POM_NAME;
     static final String MISSING_SELENIUM_POM = PATH_TO_TEST_FOLDER + "missing" + POM_NAME;
     static final String CHILD_POM = PATH_TO_TEST_FOLDER + "dummy/" + POM_NAME;

--- a/fluentlenium-core/src/test/resources/io/fluentlenium/utils/poms/parametrized/dummy_pom.xml
+++ b/fluentlenium-core/src/test/resources/io/fluentlenium/utils/poms/parametrized/dummy_pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.17.0</selenium.version>
     </properties>
 
     <dependencies>

--- a/fluentlenium-coverage-report/pom.xml
+++ b/fluentlenium-coverage-report/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-coverage-report</artifactId>
     <name>FluentLenium Coverage Report</name>

--- a/fluentlenium-cucumber/pom.xml
+++ b/fluentlenium-cucumber/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-cucumber</artifactId>
     <packaging>jar</packaging>

--- a/fluentlenium-integration-tests/pom.xml
+++ b/fluentlenium-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-integration-tests</artifactId>
     <packaging>jar</packaging>

--- a/fluentlenium-junit-jupiter/pom.xml
+++ b/fluentlenium-junit-jupiter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-junit-jupiter</artifactId>
     <name>FluentLenium JUnit Jupiter</name>

--- a/fluentlenium-junit-jupiter/src/it/junit-jupiter/pom.xml
+++ b/fluentlenium-junit-jupiter/src/it/junit-jupiter/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <it.project.version>6.0.0-SNAPSHOT</it.project.version>
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.17.0</selenium.version>
         <fluentlenium.capabilities.default>{"goog:chromeOptions": {"args": ["headless=new","no-sandbox", "disable-gpu",
             "disable-dev-shm-usage"]}}
         </fluentlenium.capabilities.default>
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-chrome-driver</artifactId>
-                <version>4.10.0</version>
+                <version>${selenium.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.bonigarcia</groupId>

--- a/fluentlenium-junit/pom.xml
+++ b/fluentlenium-junit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-junit</artifactId>
     <name>FluentLenium JUnit</name>

--- a/fluentlenium-junit/src/it/junit/pom.xml
+++ b/fluentlenium-junit/src/it/junit/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-chrome-driver</artifactId>
-                <version>4.10.0</version>
+                <version>4.17.0</version>
             </dependency>
             <dependency>
                 <groupId>io.github.bonigarcia</groupId>

--- a/fluentlenium-kotest-assertions/pom.xml
+++ b/fluentlenium-kotest-assertions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-kotest-assertions</artifactId>
     <name>FluentLenium Kotest Assertions</name>

--- a/fluentlenium-kotest/pom.xml
+++ b/fluentlenium-kotest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-kotest</artifactId>
     <name>FluentLenium Kotest</name>

--- a/fluentlenium-kotest/src/main/kotlin/io/fluentlenium/adapter/kotest/internal/KoTestFluentAdapter.kt
+++ b/fluentlenium-kotest/src/main/kotlin/io/fluentlenium/adapter/kotest/internal/KoTestFluentAdapter.kt
@@ -24,9 +24,9 @@ import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestType
-import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicReference
 
 internal class KoTestFluentAdapter(var useConfigurationOverride: () -> Configuration = { throw IllegalStateException() }) :
     IFluentAdapter,

--- a/fluentlenium-spock/pom.xml
+++ b/fluentlenium-spock/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-spock</artifactId>
     <name>FluentLenium Spock</name>

--- a/fluentlenium-spock/src/test/groovy/io/fluentlenium/adapter/spock/smoketest/SmokeTestSpec.groovy
+++ b/fluentlenium-spock/src/test/groovy/io/fluentlenium/adapter/spock/smoketest/SmokeTestSpec.groovy
@@ -2,8 +2,9 @@ package io.fluentlenium.adapter.spock.smoketest
 
 import io.fluentlenium.adapter.spock.FluentSpecification
 import io.github.bonigarcia.wdm.managers.ChromeDriverManager
+import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.ChromeDriver
-import org.openqa.selenium.support.events.EventFiringWebDriver
+import org.openqa.selenium.support.events.EventFiringDecorator
 
 import static org.assertj.core.api.Assertions.assertThat
 
@@ -15,9 +16,9 @@ class SmokeTestSpec extends FluentSpecification {
 
     def "smokeTest"() {
         expect:
-        assertThat(getDriver()).isInstanceOf(EventFiringWebDriver.class)
-        EventFiringWebDriver driver = (EventFiringWebDriver) getDriver()
-        assertThat(driver.getWrappedDriver()).isInstanceOf(ChromeDriver.class)
+        assertThat(getDriver()).isInstanceOf(EventFiringDecorator.class)
+        WebDriver driver = new EventFiringDecorator<>().decorate(getDriver());
+        assertThat(driver).isInstanceOf(ChromeDriver.class)
     }
 
 }

--- a/fluentlenium-spring-testng/pom.xml
+++ b/fluentlenium-spring-testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-spring-testng</artifactId>
     <name>FluentLenium Spring TestNG</name>

--- a/fluentlenium-spring-testng/src/test/java/io/fluentlenium/smoketest/SmokeTestEventsEnabledTest.java
+++ b/fluentlenium-spring-testng/src/test/java/io/fluentlenium/smoketest/SmokeTestEventsEnabledTest.java
@@ -1,8 +1,9 @@
 package io.fluentlenium.smoketest;
 
 import io.fluentlenium.IntegrationFluentTestNg;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.openqa.selenium.support.events.EventFiringDecorator;
 import org.springframework.test.context.ContextConfiguration;
 import org.testng.annotations.Test;
 
@@ -14,9 +15,9 @@ public class SmokeTestEventsEnabledTest extends IntegrationFluentTestNg {
     @SuppressWarnings("ConstantConditions")
     @Test
     public void smokeTest() {
-        assertThat(getDriver()).isInstanceOf(EventFiringWebDriver.class);
-        EventFiringWebDriver driver = (EventFiringWebDriver) getDriver();
-        assertThat(driver.getWrappedDriver()).isInstanceOf(ChromeDriver.class);
+        assertThat(getDriver()).isInstanceOf(EventFiringDecorator.class);
+        WebDriver driver = new EventFiringDecorator<>().decorate(getDriver());
+        assertThat(driver).isInstanceOf(ChromeDriver.class);
     }
 
 }

--- a/fluentlenium-testng/pom.xml
+++ b/fluentlenium-testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.fluentlenium</groupId>
         <artifactId>fluentlenium-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>fluentlenium-testng</artifactId>
     <name>FluentLenium TestNG</name>

--- a/fluentlenium-testng/src/it/testng/pom.xml
+++ b/fluentlenium-testng/src/it/testng/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-chrome-driver</artifactId>
-                <version>4.10.0</version>
+                <version>4.17.0</version>
             </dependency>
             <dependency>
                 <groupId>io.github.bonigarcia</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>io.fluentlenium</groupId>
     <artifactId>fluentlenium-parent</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>FluentLenium</name>
     <description>FluentLenium makes the writing of acceptance testing more easy and in a fluent way using the power of
@@ -87,6 +87,14 @@
                 <role>developer</role>
             </roles>
         </developer>
+        <developer>
+            <id>Ian</id>
+            <name>Ian Deveseleer</name>
+            <url>https://github.com/iandeveseleer</url>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
     </developers>
     <modules>
         <module>fluentlenium-core</module>
@@ -121,53 +129,80 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
-        <selenium.version>4.10.0</selenium.version>
-        <testng.version>7.8.0</testng.version>
+        <fluentlenium.capabilities.default>{"goog:chromeOptions": {"args": ["headless=new","no-sandbox", "disable-gpu",
+            "disable-dev-shm-usage"]}}</fluentlenium.capabilities.default>
+
+        <selenium.version>4.17.0</selenium.version>
         <junit5.version>5.10.1</junit5.version>
         <spring.version>6.1.1</spring.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <seleniumDevtools.artifactId>selenium-devtools-v114</seleniumDevtools.artifactId>
-        <fluentlenium.capabilities.default>{"goog:chromeOptions": {"args": ["headless=new","no-sandbox", "disable-gpu",
-            "disable-dev-shm-usage"]}}</fluentlenium.capabilities.default>
+        <seleniumDevtools.artifactId>selenium-devtools-v119</seleniumDevtools.artifactId>
+        <logback.version>1.4.14</logback.version>
+        <jcip-annotations.version>1.0-1</jcip-annotations.version>
+        <guava.version>32.1.3-jre</guava.version>
+        <commons-codec.version>1.16.0</commons-codec.version>
+        <commons-io.version>2.15.1</commons-io.version>
+        <java-client.version>8.5.1</java-client.version>
+        <webdrivermanager.version>5.6.2</webdrivermanager.version>
+        <netty-bom.version>4.1.102.Final</netty-bom.version>
+        <byte-buddy.version>1.14.10</byte-buddy.version>
+        <htmlunit.version>3.5.0</htmlunit.version>
+        <commons-lang3.version>3.14.0</commons-lang3.version>
+        <commons-text.version>1.11.0</commons-text.version>
+        <groovy.version>4.0.16</groovy.version>
+        <httpclient.version>4.5.14</httpclient.version>
+        <maven-model.version>3.9.6</maven-model.version>
+        <assertj-core.version>3.24.2</assertj-core.version>
+        <classindex.version>3.13</classindex.version>
+        <annotations.version>24.1.0</annotations.version>
+        <objenesis.version>3.3</objenesis.version>
+        <opentest4j.version>1.3.0</opentest4j.version>
+        <asm.version>9.6</asm.version>
+        <junit.version>4.13.2</junit.version>
+        <testng.version>7.8.0</testng.version>
+        <junit-platform-launcher.version>1.10.1</junit-platform-launcher.version>
+        <mockito.version>5.8.0</mockito.version>
+        <htmlunit-driver.version>4.13.0</htmlunit-driver.version>
+        <spock.version>2.3-groovy-4.0</spock.version>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.4.14</version>
+                <version>${logback.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.4.14</version>
+                <version>${logback.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.github.stephenc.jcip</groupId>
                 <artifactId>jcip-annotations</artifactId>
-                <version>1.0-1</version>
+                <version>${jcip-annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.3-jre</version>
+                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.16.0</version>
+                <version>${commons-codec.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.15.1</version>
+                <version>${commons-io.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.appium</groupId>
                 <artifactId>java-client</artifactId>
-                <version>8.5.1</version>
+                <version>${java-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.fluentlenium</groupId>
@@ -177,79 +212,79 @@
             <dependency>
                 <groupId>io.github.bonigarcia</groupId>
                 <artifactId>webdrivermanager</artifactId>
-                <version>5.6.2</version>
+                <version>${webdrivermanager.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.102.Final</version>
+                <version>${netty-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.13.2</version>
+                <version>${junit.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.14.10</version>
+                <version>${byte-buddy.version}</version>
                 <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>net.sourceforge.htmlunit</groupId>
-                <artifactId>htmlunit</artifactId>
-                <version>2.70.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.14.0</version>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.11.0</version>
+                <version>${commons-text.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
-                <version>4.0.16</version>
+                <version>${groovy.version}</version>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-bom</artifactId>
-                <version>4.0.16</version>
+                <version>${groovy.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.14</version>
+                <version>${httpclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-model</artifactId>
-                <version>3.9.6</version>
+                <version>${maven-model.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.24.2</version>
+                <version>${assertj-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.atteo.classindex</groupId>
                 <artifactId>classindex</artifactId>
-                <version>3.13</version>
+                <version>${classindex.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.htmlunit</groupId>
+                <artifactId>htmlunit</artifactId>
+                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
-                <version>24.1.0</version>
+                <version>${annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
@@ -266,33 +301,33 @@
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-launcher</artifactId>
-                <version>1.10.1</version>
+                <version>${junit-platform-launcher.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>5.8.0</version>
+                <version>${mockito.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
-                <version>5.8.0</version>
+                <version>${mockito.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
-                <version>3.3</version>
+                <version>${objenesis.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.opentest4j</groupId>
                 <artifactId>opentest4j</artifactId>
-                <version>1.3.0</version>
+                <version>${opentest4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.6</version>
+                <version>${asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
@@ -303,7 +338,7 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>htmlunit-driver</artifactId>
-                <version>4.13.0</version>
+                <version>${htmlunit-driver.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
@@ -359,12 +394,12 @@
             <dependency>
                 <groupId>org.spockframework</groupId>
                 <artifactId>spock-core</artifactId>
-                <version>2.3-groovy-4.0</version>
+                <version>${spock.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.spockframework</groupId>
                 <artifactId>spock-junit4</artifactId>
-                <version>2.3-groovy-4.0</version>
+                <version>${spock.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>


### PR DESCRIPTION
EventFiringWebDriver deprecated, refactoring to use EventFiringDecorator

https://www.selenium.dev/blog/2023/java-removal-of-deprecated-events-classes/